### PR TITLE
feat: Add logic and tests for measureMethodPerfOnCall decorator

### DIFF
--- a/lib/src/MyMath.ts
+++ b/lib/src/MyMath.ts
@@ -1,0 +1,12 @@
+export class MyMath {
+
+  /**
+  * @Method: Returns the mean value of all transferred numbers
+  * @static
+  * @Param {Number series}
+  * @Return {Mean value of all passed numbers}
+  */
+  public static mean(...numbers: number[]) {
+    return numbers.reduce((acc, val) => acc + val, 0) / numbers.length;
+  }
+}

--- a/lib/src/decorator/measureMethodPerfOnCall.ts
+++ b/lib/src/decorator/measureMethodPerfOnCall.ts
@@ -1,0 +1,26 @@
+import { performance } from 'perf_hooks';
+import { MyMath } from '../MyMath';
+
+/**
+* @Method: Returns the average execution time of the selected method.
+* @Param {int} count - Number of operations
+* @return {any} - Result of the method
+*/
+export function measureMethodPerfOnCall(count: Number = 400): any {
+  return (_target: any, _propertyKey: string, descriptor: PropertyDescriptor,
+  ) => {
+    const originalMethod = descriptor.value;
+    let result = descriptor.value();
+    descriptor.value = function() {
+      const resultArray: number[] = [];
+      for (let i = 0; i < count; i += 1) {
+        const start = performance.now();
+        originalMethod.apply(this, arguments);
+        const end = performance.now();
+        resultArray.push(end - start);
+      }
+      console.log(`The average execution time is ${MyMath.mean(...resultArray)} seconds.`);
+      return result;
+    }
+  };
+}

--- a/lib/src/decorator/measureMethodPerfOnCall.ts
+++ b/lib/src/decorator/measureMethodPerfOnCall.ts
@@ -7,8 +7,7 @@ import { MyMath } from '../MyMath';
 * @return {any} - Result of the method
 */
 export function measureMethodPerfOnCall(count: Number = 400): any {
-  return (_target: any, _propertyKey: string, descriptor: PropertyDescriptor,
-  ) => {
+  return (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) => {
     const originalMethod = descriptor.value;
     let result = descriptor.value();
     descriptor.value = function() {

--- a/lib/test/decorator/measureMethodPerfOnCall.spec.ts
+++ b/lib/test/decorator/measureMethodPerfOnCall.spec.ts
@@ -36,12 +36,12 @@ describe('PerformanceMethodByCall', () => {
       log.restore();
     });
   });
-  it('should not return console.log by method initialisation.', () => {
+  it('should not call console.log by method initialisation.', () => {
     const log = sinon.spy(console, 'log');
     sinon.assert.notCalled(log);
     log.restore();
   });
-  describe('should return output from method', () => {
+  describe('should output return value of method', () => {
     it('without arguments', () => {
       const result = new Person().calc();
       expect(result).equal(90000);

--- a/lib/test/decorator/measureMethodPerfOnCall.spec.ts
+++ b/lib/test/decorator/measureMethodPerfOnCall.spec.ts
@@ -19,7 +19,7 @@ describe('PerformanceMethodByCall', () => {
     }
   }
 
-  describe('should return console.log on method call', () => {
+  describe('should call console.log on method call', () => {
     it('without arguments.', () => {
       const log = sinon.spy(console, 'log');
       new Person().calc();

--- a/lib/test/decorator/measureMethodPerfOnCall.spec.ts
+++ b/lib/test/decorator/measureMethodPerfOnCall.spec.ts
@@ -1,0 +1,54 @@
+import { measureMethodPerfOnCall } from '../../src/decorator/measureMethodPerfOnCall';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+before(() => {
+  // fake console.log method
+  console.log = () => true;
+})
+after(() => {
+  //reset console.log
+  delete console.log;
+})
+
+describe('PerformanceMethodByCall', () => {
+  class Person {
+    @measureMethodPerfOnCall()
+    public calc(foo?: string, foobar?: string) {
+      return 300 * 300;
+    }
+  }
+
+  describe('should return console.log on method call', () => {
+    it('without arguments.', () => {
+      const log = sinon.spy(console, 'log');
+      new Person().calc();
+      new Person().calc();
+      sinon.assert.calledTwice(log);
+      log.restore();
+    });
+
+    it('with arguments.', () => {
+      const log = sinon.spy(console, 'log');
+      new Person().calc("foo");
+      new Person().calc("foo", "foobar");
+      sinon.assert.calledTwice(log);
+      log.restore();
+    });
+  });
+  it('should not return console.log by method initialisation.', () => {
+    const log = sinon.spy(console, 'log');
+    sinon.assert.notCalled(log);
+    log.restore();
+  });
+  describe('should return output from method', () => {
+    it('without arguments', () => {
+      const result = new Person().calc();
+      expect(result).equal(90000);
+    });
+    it('with arguments', () => {
+      const result = new Person().calc("foo", "foobar");
+      expect(result).equal(90000);
+    });
+  });
+});


### PR DESCRIPTION
***Logic:***
If you call the decorator above a method, you get the performance of the method when it is called.

***Tests:***
- PerformanceMethodByCall should return console.log on method call.
- PerformanceMethodByCall should not call console.log by method initialisation.
- PerformanceMethodByCall should output return value of method.

***TODOs***
- Call decorator without parentheses.